### PR TITLE
Extra edit account

### DIFF
--- a/lessons/apps.py
+++ b/lessons/apps.py
@@ -1,6 +1,0 @@
-from django.apps import AppConfig
-
-
-class LessonsConfig(AppConfig):
-    default_auto_field = 'django.db.models.BigAutoField'
-    name = 'lessons'

--- a/lessons/apps.py
+++ b/lessons/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class LessonsConfig(AppConfig):
+    default_auto_field = 'django.db.models.BigAutoField'
+    name = 'lessons'

--- a/lessons/templates/edit_account.html
+++ b/lessons/templates/edit_account.html
@@ -1,0 +1,17 @@
+{% extends 'partials/edit_account_partial.html' %}
+
+{% block loginsTitle %}Edit your login details{% endblock %}
+
+{% block loginsForm %}
+<form action="{% url 'edit_account' 'logins' %}" method="post">
+{% endblock  %}
+
+{% block passwordTitle %}Edit password{% endblock %}
+
+{% block passwordForm %}
+<form action="{% url 'edit_account' 'password' %}" method="post">
+{% endblock %}
+
+{% block doneForm %}
+<form action="{% url 'edit_account' 'done' %}" method="post">
+{% endblock  %}

--- a/lessons/templates/edit_admin.html
+++ b/lessons/templates/edit_admin.html
@@ -1,45 +1,17 @@
-{% extends 'partials/navbar.html' %}
-{% block content %}
-<div class="container">
+{% extends 'partials/edit_account_partial.html' %}
 
-  <div class="row">
-    <div class="col-12">
+{% block loginsTitle %}Edit admin's login details{% endblock %}
 
-        <h1>
-        Edit admin's login details
-        </h1>
+{% block loginsForm %}
+<form action="{% url 'edit_admin' 'logins' user_id %}" method="post">
+{% endblock  %}
 
-        <form action="{% url 'edit_admin' 'logins' user_id %}" method="post">
-            {% csrf_token %}
-            {% include 'partials/bootstrap_form.html' with form=logins_form %}
-            <input type="submit" value="Update logins" class="btn btn-primary">
-        </form>
+{% block passwordTitle %}Edit admin's password{% endblock %}
 
-    </div>
-  </div>
-
-  <div class="row">
-    <div class="col-12">
-
-        <h1>
-        Edit admin's account
-        </h1>
-
-        <form action="{% url 'edit_admin' 'password' user_id %}" method="post">
-            {% csrf_token %}
-            {% include 'partials/bootstrap_form.html' with form=password_form %}
-            <input type="submit" value="Update password" class="btn btn-primary">
-        </form>
-
-    </div>
-  </div>
-
-  <div class="col text-center">
-    <form action="{% url 'edit_admin' 'done' user_id %}" method="post">
-      {% csrf_token %}
-      <input type="submit" value="Done editing" class="btn btn-secondary">
-    </form>
-  </div>
-
-</div>
+{% block passwordForm %}
+<form action="{% url 'edit_admin' 'password' user_id %}" method="post">
 {% endblock %}
+
+{% block doneForm %}
+<form action="{% url 'edit_admin' 'done' user_id %}" method="post">
+{% endblock  %}

--- a/lessons/templates/partials/edit_account_partial.html
+++ b/lessons/templates/partials/edit_account_partial.html
@@ -1,0 +1,45 @@
+{% extends 'partials/navbar.html' %}
+{% block content %}
+<div class="container">
+
+  <div class="row">
+    <div class="col-12">
+
+        <h1>
+        {% block loginsTitle %}{% endblock  %}
+        </h1>
+
+        {% block loginsForm %}{% endblock  %}
+            {% csrf_token %}
+            {% include 'partials/bootstrap_form.html' with form=logins_form %}
+            <input type="submit" value="Update logins" class="btn btn-primary">
+        </form>
+
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col-12">
+
+        <h1>
+        {% block passwordTitle %}{% endblock %}
+        </h1>
+
+        {% block passwordForm %}{% endblock %}
+            {% csrf_token %}
+            {% include 'partials/bootstrap_form.html' with form=password_form %}
+            <input type="submit" value="Update password" class="btn btn-primary">
+        </form>
+
+    </div>
+  </div>
+
+  <div class="col text-center">
+    {% block doneForm %}{% endblock %}
+      {% csrf_token %}
+      <input type="submit" value="Done editing" class="btn btn-secondary">
+    </form>
+  </div>
+
+</div>
+{% endblock %}

--- a/lessons/templates/partials/navbar.html
+++ b/lessons/templates/partials/navbar.html
@@ -35,6 +35,7 @@
             <span class="bi-person-circle"style="margin-right:25%;"></span>
           </a>
           <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="user-account-dropdown">
+            <li><a class="dropdown-item" href="{% url 'edit_account' 'None' %}">Edit account</a></li>
             <li><hr class="dropdown-divider"></li>
             <li><a class="dropdown-item" href="{% url 'log_out' %}">Log out</a></li>
           </ul>

--- a/lessons/tests/views/test_edit_account_view.py
+++ b/lessons/tests/views/test_edit_account_view.py
@@ -1,0 +1,158 @@
+from django.conf import settings
+from lessons.forms import EditLoginsForm, EditPasswordForm
+from django.contrib.auth.hashers import check_password
+from django.test import TestCase
+from django.urls import reverse
+from lessons.models import User
+from lessons.tests.helpers import reverse_with_next
+from django.contrib import messages
+
+class EditAccountViewTestCase(TestCase):
+    """Tests of the edit_account view."""
+
+    fixtures = [
+            'lessons/tests/fixtures/default_user.json',
+            'lessons/tests/fixtures/other_users.json'
+        ]
+
+    def setUp(self):
+        self.logins_form_input = {
+            'first_name': 'John2',
+            'last_name': 'Doe2',
+            'username': 'johndoe2@example.org',
+        }
+        self.password_form_input = {
+            'current_password': 'Password123',
+            'new_password': 'NewPassword123',
+            'confirm_password': 'NewPassword123',
+        }
+        self.url = reverse('edit_account', kwargs={'action': 'None'})
+        self.user = User.objects.get(username='johndoe@example.org')
+
+    def test_edit_account_url(self):
+        self.assertEqual(self.url, '/edit_account/None')
+
+    def test_get_edit_account(self):
+        self.client.login(username=self.user.username, password='Password123')
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, 'edit_account.html')
+        logins_form = response.context['logins_form']
+        password_form = response.context['password_form']
+        self.assertTrue(isinstance(logins_form, EditLoginsForm))
+        self.assertTrue(isinstance(password_form, EditPasswordForm))
+        self.assertEqual(logins_form.instance, self.user)
+
+    def test_unsuccesful_logins_edit(self):
+        self.client.login(username=self.user.username, password='Password123')
+        self.logins_form_input['username'] = 'johndoe'
+        before_count = User.objects.count()
+        self.url = reverse('edit_account', kwargs={'action': 'logins'})
+        response = self.client.post(self.url, self.logins_form_input)
+        after_count = User.objects.count()
+        self.assertEqual(after_count, before_count)
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, 'edit_account.html')
+        logins_form = response.context['logins_form']
+        self.assertTrue(isinstance(logins_form, EditLoginsForm))
+        self.assertTrue(logins_form.is_bound)
+        self.user.refresh_from_db()
+        self.assertEqual(self.user.username, 'johndoe@example.org')
+        self.assertEqual(self.user.first_name, 'John')
+        self.assertEqual(self.user.last_name, 'Doe')
+
+    def test_unsuccesful_logins_edit_due_to_duplicate_username(self):
+        self.client.login(username=self.user.username, password='Password123')
+        self.logins_form_input['username'] = 'janedoe@example.org'
+        before_count = User.objects.count()
+        self.url = reverse('edit_account', kwargs={'action': 'logins'})
+        response = self.client.post(self.url, self.logins_form_input)
+        after_count = User.objects.count()
+        self.assertEqual(after_count, before_count)
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, 'edit_account.html')
+        logins_form = response.context['logins_form']
+        self.assertTrue(isinstance(logins_form, EditLoginsForm))
+        self.assertTrue(logins_form.is_bound)
+        self.user.refresh_from_db()
+        self.assertEqual(self.user.username, 'johndoe@example.org')
+        self.assertEqual(self.user.first_name, 'John')
+        self.assertEqual(self.user.last_name, 'Doe')
+
+    def test_succesful_logins_edit(self):
+        self.client.login(username=self.user.username, password='Password123')
+        before_count = User.objects.count()
+        self.url = reverse('edit_account', kwargs={'action': 'logins'})
+        response = self.client.post(self.url, self.logins_form_input, follow=True)
+        after_count = User.objects.count()
+        self.assertEqual(after_count, before_count)
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, 'edit_account.html')
+        messages_list = list(response.context['messages'])
+        self.assertEqual(len(messages_list), 1)
+        self.assertEqual(messages_list[0].level, messages.SUCCESS)
+        self.user.refresh_from_db()
+        self.assertEqual(self.user.username, 'johndoe2@example.org')
+        self.assertEqual(self.user.first_name, 'John2')
+        self.assertEqual(self.user.last_name, 'Doe2')
+
+    def test_succesful_password_edit(self):
+        self.client.login(username=self.user.username, password='Password123')
+        self.url = reverse('edit_account', kwargs={'action': 'password'})
+        response = self.client.post(self.url, self.password_form_input, follow=True)
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, 'edit_account.html')
+        self.user.refresh_from_db()
+        is_password_correct = check_password('NewPassword123', self.user.password)
+        self.assertTrue(is_password_correct)
+
+    def test_password_edit_unsuccesful_without_correct_previous_password(self):
+        self.client.login(username=self.user.username, password='Password123')
+        self.password_form_input['current_password'] = 'WrongPassword123'
+        self.url = reverse('edit_account', kwargs={'action': 'password'})
+        response = self.client.post(self.url, self.password_form_input, follow=True)
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, 'edit_account.html')
+        form = response.context['password_form']
+        self.assertTrue(isinstance(form, EditPasswordForm))
+        self.user.refresh_from_db()
+        is_password_correct = check_password('Password123', self.user.password)
+        self.assertTrue(is_password_correct)
+
+    def test_password_edit_unsuccesful_without_correct_confirm_password(self):
+        self.client.login(username=self.user.username, password='Password123')
+        self.password_form_input['confirm_password'] = 'WrongPassword123'
+        self.url = reverse('edit_account', kwargs={'action': 'password'})
+        response = self.client.post(self.url, self.password_form_input, follow=True)
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, 'edit_account.html')
+        form = response.context['password_form']
+        self.assertTrue(isinstance(form, EditPasswordForm))
+        self.user.refresh_from_db()
+        is_password_correct = check_password('Password123', self.user.password)
+        self.assertTrue(is_password_correct)
+
+    def test_user_is_redirected_to_home_if_no_action_given(self):
+        self.client.login(username=self.user.username, password='Password123')
+        response = self.client.post(self.url, self.password_form_input, follow=True)
+        redirect_url = reverse(settings.REDIRECT_URL_WHEN_LOGGED_IN)
+        self.assertRedirects(response, redirect_url, status_code=302, target_status_code=200)
+
+    def test_get_edit_account_redirects_when_not_logged_in(self):
+        redirect_url = reverse_with_next(settings.LOGIN_URL, self.url)
+        response = self.client.get(self.url)
+        self.assertRedirects(response, redirect_url, status_code=302, target_status_code=200)
+
+    def test_post_edit_account_password_redirects_when_not_logged_in(self):
+        self.url = reverse('edit_account', kwargs={'action': 'password'})
+        redirect_url = reverse_with_next(settings.LOGIN_URL, self.url)
+        response = self.client.post(self.url, self.password_form_input)
+        self.assertRedirects(response, redirect_url, status_code=302, target_status_code=200)
+        is_password_correct = check_password('Password123', self.user.password)
+        self.assertTrue(is_password_correct)
+
+    def test_post_edit_account_logins_redirects_when_not_logged_in(self):
+        self.url = reverse('edit_account', kwargs={'action': 'logins'})
+        redirect_url = reverse_with_next(settings.LOGIN_URL, self.url)
+        response = self.client.post(self.url, self.logins_form_input)
+        self.assertRedirects(response, redirect_url, status_code=302, target_status_code=200)

--- a/lessons/tests/views/test_edit_admin_view.py
+++ b/lessons/tests/views/test_edit_admin_view.py
@@ -142,7 +142,7 @@ class EditAdminViewTestCase(TestCase):
         self.assertTemplateUsed(response, 'edit_admin.html')
         form = response.context['password_form']
         self.assertTrue(isinstance(form, EditPasswordForm))
-        self.user.refresh_from_db()
+        self.peter.refresh_from_db()
         is_password_correct = check_password('Password123', self.peter.password)
         self.assertTrue(is_password_correct)
 
@@ -158,7 +158,7 @@ class EditAdminViewTestCase(TestCase):
         self.assertTemplateUsed(response, 'edit_admin.html')
         form = response.context['password_form']
         self.assertTrue(isinstance(form, EditPasswordForm))
-        self.user.refresh_from_db()
+        self.peter.refresh_from_db()
         is_password_correct = check_password('Password123', self.peter.password)
         self.assertTrue(is_password_correct)
 
@@ -173,6 +173,20 @@ class EditAdminViewTestCase(TestCase):
     def test_get_edit_admin_redirects_when_not_logged_in(self):
         redirect_url = reverse_with_next(settings.LOGIN_URL, self.url)
         response = self.client.get(self.url)
+        self.assertRedirects(response, redirect_url, status_code=302, target_status_code=200)
+
+    def test_post_edit_admin_password_redirects_when_not_logged_in(self):
+        self.url = reverse('edit_admin', kwargs={'action': 'password', 'user_id': self.peter.id})
+        redirect_url = reverse_with_next(settings.LOGIN_URL, self.url)
+        response = self.client.post(self.url, self.password_form_input)
+        self.assertRedirects(response, redirect_url, status_code=302, target_status_code=200)
+        is_password_correct = check_password('Password123', self.user.password)
+        self.assertTrue(is_password_correct)
+
+    def test_post_edit_admin_logins_redirects_when_not_logged_in(self):
+        self.url = reverse('edit_admin', kwargs={'action': 'logins', 'user_id': self.peter.id})
+        redirect_url = reverse_with_next(settings.LOGIN_URL, self.url)
+        response = self.client.post(self.url, self.logins_form_input)
         self.assertRedirects(response, redirect_url, status_code=302, target_status_code=200)
 
     def test_logged_out_director_cannot_access_edit_admin(self):

--- a/lessons/views.py
+++ b/lessons/views.py
@@ -70,6 +70,43 @@ def log_out(request):
     logout(request)
     return redirect('main')
 
+"""
+A view for all users to edit their account details
+"""
+@login_required
+def edit_account(request, action):
+    edit_logins_form = EditLoginsForm(instance=request.user)
+    edit_password_form = EditPasswordForm()
+
+    if request.method == 'POST':
+        # User chose to update their login info
+        if action == 'logins':
+            edit_logins_form = EditLoginsForm(instance=request.user, data=request.POST)
+            if edit_logins_form.is_valid():
+                messages.add_message(request, messages.SUCCESS, "Your login information has been updated!")
+                edit_logins_form.save()
+                return redirect('edit_account', 'None')
+
+        # User chose to update their password
+        elif action == 'password':
+            edit_password_form = EditPasswordForm(data=request.POST)
+            if edit_password_form.is_valid():
+                current_password = edit_password_form.cleaned_data.get('current_password')
+                if check_password(current_password, request.user.password):
+                    new_password = edit_password_form.cleaned_data.get('new_password')
+                    request.user.set_password(new_password)
+                    request.user.save()
+                    login(request, request.user)
+                    messages.add_message(request, messages.SUCCESS, "Your password has been updated!")
+                    return redirect('edit_account', 'None')
+
+        # User is done editing
+        else:
+            return redirect(settings.REDIRECT_URL_WHEN_LOGGED_IN)
+
+    return render(request, 'edit_account.html', {'logins_form': edit_logins_form, 'password_form': edit_password_form})
+
+
 @login_required
 def bookings(request):
     return render(request, 'bookings.html')

--- a/msms/urls.py
+++ b/msms/urls.py
@@ -25,6 +25,7 @@ urlpatterns = [
     path('log_out/', views.log_out, name='log_out'),
     path('register/', views.register, name='register'),
     path('register_super/<user_type>', views.register_super, name='register_super'),
+    path('edit_account/<action>', views.edit_account, name='edit_account'),
     path('new_lesson/', views.new_lesson, name='new_lesson'),
     path('lesson_requests/', views.lesson_requests, name='lesson_requests'),
     path('bookings/', views.bookings, name='bookings'),


### PR DESCRIPTION
Hi reviewer! This branch's functionality is not really in the epics, but I did it for the sake of completeness.

**Basically** it's the ability for all users to edit their account info, i.e. name, username and password. I already did this before because in one of the tasks, the director needs to be able to edit admin accounts. Therefore, I just reused most of the code and made it for all users.

### Here is what I added:
- A button in the navbar for all users to access the page (you can access it when you click on the profile picture menu)
- A view/url/template for 'edit_account'
- A test file for the view only, as the forms are already have test files